### PR TITLE
Disable nightly builds ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     branches: [main]
   release:
     types: [published]
-  schedule:
-    - cron: '30 20 * * *' # Warning: Timezone dep - 20:00 is 1:00
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
@vgvassilev Now that xeus-clang-repl is being depreciated can you merge this PR so that the nightly builds on the ci are stopped? These builds are using up runners which could be doing something useful.