### PR TITLE
Fix docker to work for releases.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,15 +187,12 @@ RUN \
     gh_f_repo_name=${gh_repo_name} && \
     h=$(git rev-parse HEAD) && \
     echo "Debug: Head h: $h" && \
-    br=$(git rev-parse --abbrev-ref HEAD) && \
-    echo "Debug: Branch br: $br" && \
     #FIXME: if `$h` is not pushed upstream this fails. We should just diagnose and move on.
-    #git show-ref --head && echo $? && \
-    #git show-ref --head | grep "$h" && echo $? && \
-    #git show-ref --head | grep "$h" | grep -E "remotes|tags" && echo $? && \
-    #git show-ref --head | grep "$h" | grep -E "remotes|tags" | grep -o '[^/ ]*$' && echo $? && \
-    #arr1=$(git show-ref --head | grep "$h" | grep -E "remotes|tags" | grep -o '[^/ ]*$') && echo $? && \
-    arr1=$br && \
+    git show-ref --head && echo $? && \
+    git show-ref --head | grep "$h" && echo $? && \
+    git show-ref --head | grep "$h" | grep -E "remotes|tags" && echo $? && \
+    git show-ref --head | grep "$h" | grep -E "remotes|tags" | grep -o '[^/ ]*$' && echo $? && \
+    arr1=$(git show-ref --head | grep "$h" | grep -E "remotes|tags" | grep -o '[^/ ]*$') && echo $? && \
     gh_repo_branch="${arr1[*]//\|}" && \
     gh_repo_branch_regex=" ${gh_repo_branch//$'\n'/ | } " && \
     gh_repo_branch_regex=$(echo "$gh_repo_branch_regex" | sed -e 's/[]\/$*.^[]/\\\\&/g') && \

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -46,7 +46,12 @@ void* createInterpreter(const Args &ExtraArgs = {}) {
 }
 
 namespace xcpp {
-void interpreter::configure_impl() {}
+
+void interpreter::configure_impl()
+{
+    xeus::register_interpreter(this);
+}
+
 
 interpreter::interpreter(int argc, const char *const *argv)
     : //          m_input_validator(),


### PR DESCRIPTION
If we want the doker image to work for release tags (using clang-dev from the release build attachment) and when developing in PR (using a temporary -- 90 days -- created artifacts with clang-dev), the discovery and download must be consistent with the release tag or the branch name of PR.